### PR TITLE
포스트 삭제 기능 개발 및 오타 수정

### DIFF
--- a/src/main/java/com/example/sns/controller/PostController.java
+++ b/src/main/java/com/example/sns/controller/PostController.java
@@ -28,4 +28,10 @@ public class PostController {
         Post post = postService.modify(request.getTitle(), request.getBody(), authentication.getName(), postId);
         return Response.success(PostResponse.fromPost(post));
     }
+
+    @DeleteMapping("/{postId}")
+    public Response<Void> delete(@PathVariable Integer postId, Authentication authentication) {
+        postService.delete(authentication.getName(), postId);
+        return Response.success();
+    }
 }

--- a/src/test/java/com/example/sns/controller/PostControllerTest.java
+++ b/src/test/java/com/example/sns/controller/PostControllerTest.java
@@ -22,8 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -131,7 +130,7 @@ public class PostControllerTest {
     @Test
     @WithMockUser
     void 포스트삭제() throws Exception {
-        mockMvc.perform(put("/api/v1/posts/1")
+        mockMvc.perform(delete("/api/v1/posts/1")
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())
                 .andExpect(status().isOk());
@@ -140,7 +139,7 @@ public class PostControllerTest {
     @Test
     @WithAnonymousUser
     void 포스트삭제시_로그인하지_않은경우() throws Exception {
-        mockMvc.perform(put("/api/v1/posts/1")
+        mockMvc.perform(delete("/api/v1/posts/1")
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())
                 .andExpect(status().isUnauthorized());
@@ -152,7 +151,7 @@ public class PostControllerTest {
         //mocking
         doThrow(new SnsApplicationException(ErrorCode.INVALID_PERMISSION)).when(postService).delete(any(), any());
 
-        mockMvc.perform(put("/api/v1/posts/1")
+        mockMvc.perform(delete("/api/v1/posts/1")
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())
                 .andExpect(status().isUnauthorized());
@@ -164,7 +163,7 @@ public class PostControllerTest {
         //mocking
         doThrow(new SnsApplicationException(ErrorCode.POST_NOT_FOUND)).when(postService).delete(any(), any());
 
-        mockMvc.perform(put("/api/v1/posts/1")
+        mockMvc.perform(delete("/api/v1/posts/1")
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())
                 .andExpect(status().isNotFound());

--- a/src/test/java/com/example/sns/controller/UserControllerTest.java
+++ b/src/test/java/com/example/sns/controller/UserControllerTest.java
@@ -6,7 +6,6 @@ import com.example.sns.exception.ErrorCode;
 import com.example.sns.exception.SnsApplicationException;
 import com.example.sns.model.User;
 import com.example.sns.service.UserService;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/example/sns/service/PostServiceTest.java
+++ b/src/test/java/com/example/sns/service/PostServiceTest.java
@@ -125,7 +125,7 @@ public class PostServiceTest {
     }
 
     @Test
-    void 포스트삭시_포스트가_존재하지않는_경우() {
+    void 포스트삭제시_포스트가_존재하지않는_경우() {
         String userName = "userName";
         Integer postId = 1;
 


### PR DESCRIPTION
이 PR은 게시글 삭제 기능을 추가한다.

**게시글 삭제 기능 구현**
PostController에 게시글 삭제 요청을 처리하는 DELETE 메서드 추가.

**오타 수정**
PutControllerTest의 삭제부분 put -> delete로 수정
UserControllerTest 안쓰는 import문 정리
PostServiceTest 포스트삭시 -> 포스트삭제시로 오타 수정