### PR TITLE
피드 목록 - 기능 테스트 작성

### DIFF
--- a/src/main/java/com/example/sns/controller/PostController.java
+++ b/src/main/java/com/example/sns/controller/PostController.java
@@ -7,8 +7,11 @@ import com.example.sns.controller.response.Response;
 import com.example.sns.model.Post;
 import com.example.sns.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @RequestMapping("/api/v1/posts")
@@ -33,5 +36,15 @@ public class PostController {
     public Response<Void> delete(@PathVariable Integer postId, Authentication authentication) {
         postService.delete(authentication.getName(), postId);
         return Response.success();
+    }
+
+    @GetMapping
+    public Response<Page<PostResponse>> list(Pageable pageable, Authentication authentication) {
+        return Response.success(postService.list(pageable).map(PostResponse::fromPost));
+    }
+
+    @GetMapping("/my")
+    public Response<Page<PostResponse>> my(Pageable pageable, Authentication authentication) {
+        return Response.success(postService.my(authentication.getName(), pageable).map(PostResponse::fromPost));
     }
 }

--- a/src/main/java/com/example/sns/repository/PostEntityRepository.java
+++ b/src/main/java/com/example/sns/repository/PostEntityRepository.java
@@ -1,10 +1,15 @@
 package com.example.sns.repository;
 
 import com.example.sns.model.entity.PostEntity;
+import com.example.sns.model.entity.UserEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostEntityRepository extends JpaRepository<PostEntity, Integer> {
+
+    public Page<PostEntity> findAllByUser(UserEntity entity, Pageable pageable);
 
 }

--- a/src/main/java/com/example/sns/service/PostService.java
+++ b/src/main/java/com/example/sns/service/PostService.java
@@ -8,6 +8,8 @@ import com.example.sns.model.entity.UserEntity;
 import com.example.sns.repository.PostEntityRepository;
 import com.example.sns.repository.UserEntityRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,4 +64,16 @@ public class PostService {
 
         postEntityRepository.delete(postEntity);
     }
+
+    public Page<Post> list(Pageable pageable) {
+        return postEntityRepository.findAll(pageable).map(Post::fromEntity);
+    }
+
+    public Page<Post> my(String userName,  Pageable pageable) {
+        UserEntity userEntity = userEntityRepository.findByUserName(userName).orElseThrow(() ->
+                new SnsApplicationException(ErrorCode.USER_NOT_FOUND, String.format("%s not founded", userName)));
+
+        return postEntityRepository.findAllByUser(userEntity, pageable).map(Post::fromEntity);
+    }
+
 }

--- a/src/test/java/com/example/sns/controller/PostControllerTest.java
+++ b/src/test/java/com/example/sns/controller/PostControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -167,6 +168,50 @@ public class PostControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser
+    void 피드목록() throws Exception {
+        when(postService.list(any())).thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/v1/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithAnonymousUser
+    void 피드목록요청시_로그인하지_않은경우() throws Exception {
+        when(postService.list(any())).thenReturn(Page.empty());
+
+        mockMvc.perform(delete("/api/v1/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    void 내피드목록() throws Exception {
+        when(postService.my(any(), any())).thenReturn(Page.empty());
+
+        mockMvc.perform(get("/api/v1/posts/my")
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithAnonymousUser
+    void 내피드목록요청시_로그인하지_않은경우() throws Exception {
+        when(postService.my(any(), any())).thenReturn(Page.empty());
+
+        mockMvc.perform(delete("/api/v1/posts/my")
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isUnauthorized());
     }
 }
 

--- a/src/test/java/com/example/sns/service/PostServiceTest.java
+++ b/src/test/java/com/example/sns/service/PostServiceTest.java
@@ -13,10 +13,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -152,5 +155,21 @@ public class PostServiceTest {
 
         SnsApplicationException e = Assertions.assertThrows(SnsApplicationException.class, () -> postService.delete(userName, 1));
         Assertions.assertEquals(ErrorCode.INVALID_PERMISSION, e.getErrorCode());
+    }
+
+    @Test
+    void 피드목록요청이_성공한경우() {
+
+        Pageable pageable = mock(Pageable.class);
+        when(postEntityRepository.findAll(pageable)).thenReturn(Page.empty());
+        Assertions.assertDoesNotThrow(()-> postService.list(pageable));
+    }
+
+    @Test
+    void 내피드목록요청이_성공한경우() {
+
+        Pageable pageable = mock(Pageable.class);
+        when(postEntityRepository.findAllByUser(any(), eq(pageable))).thenReturn(Page.empty());
+        Assertions.assertDoesNotThrow(()-> postService.my("", pageable));
     }
 }


### PR DESCRIPTION
이 PR은 피드 목록 조회 및 내 게시글 조회 기능을 추가하고, 해당 기능에 대한 테스트를 작성한다.

**피드 및 내 게시글 조회 기능 추가**
- 모든 유저의 게시글을 조회하는 기능과 로그인한 사용자의 게시글만 조회하는 기능을 추가 (Controller, Service, Repository).
- 유저별 게시글 조회를 위한 findAllByUser 메서드 추가.

**피드 및 내 게시글 조회 테스트 추가**
- 로그인 상태와 비로그인 상태에서의 피드 및 내 게시글 조회 테스트 추가 (ControllerTest, ServiceTest).
- 각각의 기능이 정상적으로 작동하는지 검증.