### PR TITLE
피드 목록 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,8 @@ task cleanFrontEnd(type: Delete) {
 	delete "$projectDir/front-end/static", "$projectDir/front-end/node_modules"
 }
 
-//npmBuild.dependsOn npmInstall
-//copyFrontEnd.dependsOn npmBuild
-//compileJava.dependsOn copyFrontEnd
-//
-//clean.dependsOn cleanFrontEnd
+npmBuild.dependsOn npmInstall
+copyFrontEnd.dependsOn npmBuild
+compileJava.dependsOn copyFrontEnd
+
+clean.dependsOn cleanFrontEnd

--- a/src/main/java/com/example/sns/controller/UserController.java
+++ b/src/main/java/com/example/sns/controller/UserController.java
@@ -23,13 +23,13 @@ public class UserController {
     // TODO : implement
     @PostMapping("/join")
     public Response<UserJoinResponse> join(@RequestBody UserJoinRequest request) {
-        User user = userService.join(request.getUserName(), request.getPassword());
+        User user = userService.join(request.getName(), request.getPassword());
         return Response.success(UserJoinResponse.fromUser(user));
     }
 
     @PostMapping("/login")
     public Response<UserLoginResponse> login(@RequestBody UserLoginRequest request) {
-        String token = userService.login(request.getUserName(), request.getPassword());
+        String token = userService.login(request.getName(), request.getPassword());
         return Response.success(new UserLoginResponse(token));
     }
 }

--- a/src/main/java/com/example/sns/controller/request/UserJoinRequest.java
+++ b/src/main/java/com/example/sns/controller/request/UserJoinRequest.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class UserJoinRequest {
-    private String userName;
+    private String name;
     private String password;
 }

--- a/src/main/java/com/example/sns/controller/request/UserLoginRequest.java
+++ b/src/main/java/com/example/sns/controller/request/UserLoginRequest.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class UserLoginRequest {
-    private String userName;
+    private String name;
     private String password;
 }

--- a/src/test/java/com/example/sns/service/PostServiceTest.java
+++ b/src/test/java/com/example/sns/service/PostServiceTest.java
@@ -159,7 +159,6 @@ public class PostServiceTest {
 
     @Test
     void 피드목록요청이_성공한경우() {
-
         Pageable pageable = mock(Pageable.class);
         when(postEntityRepository.findAll(pageable)).thenReturn(Page.empty());
         Assertions.assertDoesNotThrow(()-> postService.list(pageable));
@@ -167,9 +166,11 @@ public class PostServiceTest {
 
     @Test
     void 내피드목록요청이_성공한경우() {
-
         Pageable pageable = mock(Pageable.class);
+        UserEntity user = mock(UserEntity.class);
+        when(userEntityRepository.findByUserName(any())).thenReturn(Optional.of(user));
         when(postEntityRepository.findAllByUser(any(), eq(pageable))).thenReturn(Page.empty());
+
         Assertions.assertDoesNotThrow(()-> postService.my("", pageable));
     }
 }


### PR DESCRIPTION
이 PR은 프론트엔드와 변수명 통일을 위해 userName 변수를 name으로 일괄 변경하고, 내 피드 목록 요청 테스트에서 누락된 UserEntity 모킹 처리를 추가한 사항을 포함한다.

- userName -> name으로 변수명 일괄 변경 (프론트엔드와의 일관성 유지)
- userEntityRepository.findByUserName()에 대한 UserEntity 모킹 추가
  - 기존 테스트에서 유저 정보를 찾는 부분에 모킹이 누락된 문제 해결
- 내 피드 목록 조회 테스트에서 유저 정보 처리 로직 개선